### PR TITLE
Make sssd wait for active/working network connection

### DIFF
--- a/roles/freeipa-client/files/systemd/system/autofs.service
+++ b/roles/freeipa-client/files/systemd/system/autofs.service
@@ -7,7 +7,6 @@ Wants=network-online.target
 Type=forking
 PIDFile=/run/autofs.pid
 EnvironmentFile=-/etc/default/autofs
-ExecStartPre=/bin/sleep 10
 ExecStart=/usr/sbin/automount $OPTIONS --pid-file /run/autofs.pid
 ExecReload=/bin/kill -HUP $MAINPID
 TimeoutSec=180

--- a/roles/freeipa-client/files/systemd/system/sssd.service
+++ b/roles/freeipa-client/files/systemd/system/sssd.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=System Security Services Daemon
+# SSSD must be running before we permit user sessions
+Before=systemd-user-sessions.service nss-user-lookup.target autofs.service
+# Wait until we're online before starting
+Wants=network-online.target nss-user-lookup.target
+After=network-online.target
+
+[Service]
+ExecStart=/usr/sbin/sssd -i -f
+Type=notify
+NotifyAccess=main
+PIDFile=/var/run/sssd.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/freeipa-client/tasks/ubuntu.yml
+++ b/roles/freeipa-client/tasks/ubuntu.yml
@@ -48,6 +48,13 @@
   tags:
   - auth
 
+- name: Install sssd.service
+  copy:
+    src: systemd/system/sssd.service
+    dest: /etc/systemd/system/autofs.service
+  tags:
+    auth
+
 - name: Restart rpc-gssd
   service: name=rpc-gssd state=restarted
   tags: [auth]


### PR DESCRIPTION
This seemingly fixes the automount issue that's been plaguing us forever with the Ubuntu workstations.